### PR TITLE
plex.yml: fact gathering before running playbook

### DIFF
--- a/tasks/plex.yml
+++ b/tasks/plex.yml
@@ -1,4 +1,5 @@
 ---
+- setup:
 - block:
     - name: Add Plex Yum repo
       yum_repository:


### PR DESCRIPTION
Consider doing fact gathering via invoking the setup module before running the playbook. Otherwise checks like 'when: ansible_os_family == ""' will likely fail.