### PR TITLE
Fix Key & Repo Install Following apt-key deprecation

### DIFF
--- a/tasks/plex.yml
+++ b/tasks/plex.yml
@@ -30,15 +30,17 @@
         state: present
 
     - name: Add Plex apt key (Ubuntu & Debian with systemd)
-      apt_key:
+      get_url:
         url: https://downloads.plex.tv/plex-keys/PlexSign.key
-        state: present
+        dest: /etc/apt/keyrings/plexmediaserver.asc
+        mode: '0644'
+        force: true
 
     - name: Add Plex apt repo (Ubuntu & Debian with systemd)
       apt_repository:
-        repo: deb https://downloads.plex.tv/repo/deb public main
+        repo: deb [signed-by=/etc/apt/keyrings/plexmediaserver.asc] https://downloads.plex.tv/repo/deb public main
         state: present
-      changed_when: false
+        filename: plexmediaserver
 
     - name: Apt install Plex
       apt:


### PR DESCRIPTION
Hey @wilmardo,

The key and repo install is no longer working on recent Debian/Ubuntu releases (Bookworm, 22.04 Jammy Jellyfish). `apt-key` is deprecated in favor of `trusted.gpg.d`.

Updated the installation to use keyring/trusted.gpg.d. 

See https://www.jeffgeerling.com/blog/2022/aptkey-deprecated-debianubuntu-how-fix-ansible